### PR TITLE
feat: expose the ES module as pkg.module field

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   ],
   "license": "BSD-3-Clause",
   "main": "build/d3-gridding.js",
-  "jsnext:main": "index",
+  "module": "index.js",
+  "jsnext:main": "index.js",
   "homepage": "https://github.com/romsson/d3-gridding",
   "repository": {
     "type": "git",


### PR DESCRIPTION
See https://github.com/rollup/rollup/wiki/pkg.module.

Should also fix #17.